### PR TITLE
fix for case sensitive file systems and os

### DIFF
--- a/SNTPtimeESP-master/SNTPtime.h
+++ b/SNTPtimeESP-master/SNTPtime.h
@@ -34,7 +34,7 @@ V1.0 2016-8-3
 
 #include <Arduino.h>
 #include <ESP8266WiFi.h>
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 #include <time.h>
 
 


### PR DESCRIPTION
You get an error when compiling your library on Linux. This is due to case sensitivity of the file system.
